### PR TITLE
add functionality to create thin pool / volume on Linux LVM to lvol module

### DIFF
--- a/system/lvol.py
+++ b/system/lvol.py
@@ -91,6 +91,12 @@ EXAMPLES = '''
 
 # Remove the logical volume.
 - lvol: vg=firefly lv=test state=absent force=yes
+
+# Create a thin pool of 512g.
+- lvol: vg=firefly thinpool=testpool size=512g
+
+# Create a thin volume of 128g.
+- lvol: vg=firefly lv=test thinpool=testpool size=128g
 '''
 
 import re


### PR DESCRIPTION
On Linux's LVM, thin provisioned volume is supported.

This PR add functionality to create thin pool / volume on Linux's LVM to lvol module.

Linux LVM's thin provisioning volume operation is described here: 
https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/6/html/Logical_Volume_Manager_Administration/thinly_provisioned_volume_creation.html
